### PR TITLE
Pass params for every individual request

### DIFF
--- a/src/core/BaseService.ts
+++ b/src/core/BaseService.ts
@@ -103,7 +103,7 @@ class BaseService {
     config?: AxiosRequestConfig,
   ): Promise<T>
   patch<T>(id: string | number, payload?: any, config?: AxiosRequestConfig) {
-    const parameter = id && !isObject(id) ? id : ''
+    const parameter = id && !isObject(id) ? `/${id}` : ''
     return this.submit<T>('patch', parameter, payload, { config })
   }
 
@@ -112,7 +112,7 @@ class BaseService {
   }
 
   delete<T>(id: string | number) {
-    return this.submit<T>('delete', id)
+    return this.submit<T>('delete', `/${id}`)
   }
 
   remove<T>(id: string | number) {


### PR DESCRIPTION
Hey!

This is more of a suggestion. I don't expect that you will merge this. But I thought I'd just do the work and see what you think.

Setting the params for a proxy incurs a bunch of boilerplate and is error-prone - we've had a few bugs in our project because sometimes params were still present from a previous request and we did not properly call `removeParameters`. Also the { fn } field in the Vuex module is only used for params, right? It can also be removed.

Heads-up, I didn't actually test this, but I don't think there are any breaking changes. It's more of a pitching of the idea to remove static Query params and just pass them in to an individual API call.

Some screenshots that show what I am talking about:
![removeParams](https://user-images.githubusercontent.com/82488647/167293612-a962e8ab-dfe2-4582-9171-52d9f4d81f49.PNG)
A bunch of boilerplate

![allActions](https://user-images.githubusercontent.com/82488647/167293639-99b65602-dcb9-4111-affb-4438b9eebe12.PNG)
Introduces complexity that doesn't need to be there

![compareFns](https://user-images.githubusercontent.com/82488647/167293646-9839b017-9a3a-47d1-9496-04ded4eee054.PNG)
Comparison between typical function call before and after. Less boilerplate but more accessible.

Cheers 🍺 


Edit: In my PR I only handled the case for get route. In my experience queries are not really used for any other endpoint. But it would be easy to add them to the other route handlers as well.